### PR TITLE
Add endpoint to create generic accounts

### DIFF
--- a/inbox/api/jsc_api.py
+++ b/inbox/api/jsc_api.py
@@ -118,3 +118,59 @@ def auth_callback():
         })
 
         return make_response( (resp, 201, { 'Content-Type': 'application/json' }))
+
+@app.route('/create_account', methods=['POST'])
+def create_account():
+    g.parser.add_argument('target', type=int, location='args')
+    g.parser.add_argument('email', required=True, type=bounded_str, location='form')
+    g.parser.add_argument('smtp_host', required=True, type=bounded_str, location='form')
+    g.parser.add_argument('smtp_port', required=True, type=int, location='form')
+    g.parser.add_argument('smtp_username', required=True, type=bounded_str, location='form')
+    g.parser.add_argument('smtp_password', required=True, type=bounded_str, location='form')
+    g.parser.add_argument('imap_host', required=True, type=bounded_str, location='form')
+    g.parser.add_argument('imap_port', required=True, type=int, location='form')
+    g.parser.add_argument('imap_username', required=True, type=bounded_str, location='form')
+    g.parser.add_argument('imap_password', required=True, type=bounded_str, location='form')
+    g.parser.add_argument('ssl_required', required=True, type=bool, location='form')
+
+    args = strict_parse_args(g.parser, request.args)
+    shard = (args.get('target') or 0) >> 48
+
+    with session_scope(shard) as db_session:
+        account = db_session.query(Account).filter_by(email_address=args['email']).first()
+        if account is not None:
+            resp = simplejson.dumps({ 'message': 'Account already exists', 'type': 'custom_api_error' })
+            return make_response((resp, 400, { 'Content-Type': 'application/json' }))
+
+        provider_auth_info = dict(provider='custom',
+                                  email=args['email'],
+                                  imap_server_host=args['imap_host'],
+                                  imap_server_port=args['imap_port'],
+                                  imap_username=args['imap_username'],
+                                  imap_password=args['imap_password'],
+                                  smtp_server_host=args['smtp_host'],
+                                  smtp_server_port=args['smtp_port'],
+                                  smtp_username=args['smtp_username'],
+                                  smtp_password=args['smtp_password'],
+                                  ssl_required=args['ssl_required'])
+
+        auth_handler = handler_from_provider(provider_auth_info['provider'])
+        account = auth_handler.create_account(args['email'], provider_auth_info)
+
+        try:
+            resp = None
+
+            if auth_handler.verify_account(account):
+                db_session.add(account)
+                db_session.commit()
+                resp = simplejson.dumps({
+                    'account_id': account.public_id,
+                    'namespace_id': account.namespace.public_id
+                })
+            else:
+                resp = simplejson.dumps({ 'message': 'Account verification failed', 'type': 'api_error' })
+
+            return make_response((resp, 201, { 'Content-Type': 'application/json' }))
+        except NotSupportedError as e:
+            resp = simplejson.dumps({ 'message': str(e), type: 'custom_api_error' })
+            return make_response((resp, 400, { 'Content-Type': 'application/json' }))

--- a/inbox/api/jsc_api.py
+++ b/inbox/api/jsc_api.py
@@ -20,6 +20,11 @@ app = Blueprint(
 
 app.log_exception = log_exception
 
+DEFAULT_IMAP_PORT = 143
+DEFAULT_IMAP_SSL_PORT = 993
+DEFAULT_SMTP_PORT = 25
+DEFAULT_SMTP_SSL_PORT = 465
+
 @app.before_request
 def start():
     request.environ['log_context'] = {
@@ -124,11 +129,11 @@ def create_account():
     g.parser.add_argument('target', type=int, location='args')
     g.parser.add_argument('email', required=True, type=bounded_str, location='form')
     g.parser.add_argument('smtp_host', required=True, type=bounded_str, location='form')
-    g.parser.add_argument('smtp_port', required=True, type=int, location='form')
+    g.parser.add_argument('smtp_port', type=int, location='form')
     g.parser.add_argument('smtp_username', required=True, type=bounded_str, location='form')
     g.parser.add_argument('smtp_password', required=True, type=bounded_str, location='form')
     g.parser.add_argument('imap_host', required=True, type=bounded_str, location='form')
-    g.parser.add_argument('imap_port', required=True, type=int, location='form')
+    g.parser.add_argument('imap_port', type=int, location='form')
     g.parser.add_argument('imap_username', required=True, type=bounded_str, location='form')
     g.parser.add_argument('imap_password', required=True, type=bounded_str, location='form')
     g.parser.add_argument('ssl_required', required=True, type=bool, location='form')
@@ -145,11 +150,11 @@ def create_account():
         provider_auth_info = dict(provider='custom',
                                   email=args['email'],
                                   imap_server_host=args['imap_host'],
-                                  imap_server_port=args['imap_port'],
+                                  imap_server_port=(args.get('imap_port') or DEFAULT_IMAP_SSL_PORT),
                                   imap_username=args['imap_username'],
                                   imap_password=args['imap_password'],
                                   smtp_server_host=args['smtp_host'],
-                                  smtp_server_port=args['smtp_port'],
+                                  smtp_server_port=(args.get('smtp_port') or DEFAULT_SMTP_SSL_PORT),
                                   smtp_username=args['smtp_username'],
                                   smtp_password=args['smtp_password'],
                                   ssl_required=args['ssl_required'])


### PR DESCRIPTION
Usage example:

```ruby

data = {
  email: 'carlos@jobscore.com',
  imap_host: 'imap.gmail.com',
  imap_port: 993,
  imap_username: '...',
  imap_password: '...',
  smtp_host: 'smtp.gmail.com',
  ...
  requires_ssl: true
}

Excon.post('http://0.0.0.0:5555/c/create_account', 
  body: URI.encode_www_form(data),
  headers: { 'Content-Type' => 'application/x-www-form-urlencoded' })
```

Story [#143433465](https://www.pivotaltracker.com/story/show/143433465)