### PR TITLE
Create API to retry sync in Nylas for accounts that are in the invalid state

### DIFF
--- a/inbox/api/jsc_api.py
+++ b/inbox/api/jsc_api.py
@@ -121,9 +121,9 @@ def auth_callback():
 
         return make_response( (resp, 201, { 'Content-Type': 'application/json' }))
 
-@app.route('/retry_sync', methods=['get'])
+@app.route('/retry_sync', methods=['POST'])
 def retry_sync():
-    g.parser.add_argument('namespace_public_id', required=True, type=valid_public_id, location='args')
+    g.parser.add_argument('namespace_public_id', required=True, type=valid_public_id, location='form')
 
     args = strict_parse_args(g.parser, request.args)
     shard = (args.get('target') or 0) >> 48
@@ -138,7 +138,9 @@ def retry_sync():
                 return make_response((resp, 400, { 'Content-Type': 'application/json' }))
 
             account = namespace.account
-            resp = json.dumps(account.sync_status, default=json_util.default)
+            resp = simplejson.dumps({
+                'error': account.sync_status['sync_error']
+            })
             account.sync_state = 'running'
             account.sync_should_run = True
             db_session.commit()


### PR DESCRIPTION
[PT](https://www.pivotaltracker.com/story/show/145296107)


Response should be the sync error.

Sample output
```bash
curl -X POST -F "account_id=wrong_id"  http://localhost:5555/c/enable_sync

> {"message": "Namespace do not exists", "type": "custom_api_error"}
```

Sample output
```bash
curl -X POST -F "account_id=c3usqb4mp9sbxlkh9u2gykswhi"  http://localhost:5555/c/enable_sync

> {"error": {"message": "", "traceback": "Traceback (most recent call last):\n  File \"/vagrant/inbox/util/concurrency.py\", line 71, in wrapped\n    return func(*args, **kwargs)\n  File \"/vagrant/inbox/mailsync/backends/imap/generic.py\", line 204, in _run_impl\n    self.state = self.state_handlers[old_state]()\n  File \"/vagrant/inbox/util/concurrency.py\", line 71, in wrapped\n    return func(*args, **kwargs)\n  File \"/vagrant/inbox/mailsync/backends/imap/generic.py\", line 312, in initial_sync\n    self.initial_sync_impl(crispin_client)\n  File \"/vagrant/inbox/mailsync/backends/gmail.py\", line 271, in initial_sync_impl\n    self.batch_download_uids(crispin_client, uids, g_metadata)\n  File \"/vagrant/inbox/mailsync/backends/gmail.py\", line 472, in batch_download_uids\n    self.download_and_commit_uids(crispin_client, batch)\n  File \"/vagrant/inbox/mailsync/backends/gmail.py\", line 407, in download_and_commit_uids\n    msg)\n  File \"/vagrant/inbox/mailsync/backends/imap/generic.py\", line 475, in create_message\n    new_uid = common.create_imap_message(db_session, acct, folder, msg)\n  File \"/vagrant/inbox/mailsync/backends/imap/common.py\", line 192, in create_imap_message\n    body_string=msg.body)\n  File \"/vagrant/inbox/models/message.py\", line 257, in create_from_synced\n    save_to_blockstore(msg.data_sha256, body_string)\n  File \"/vagrant/inbox/util/blockstore.py\", line 39, in save_to_blockstore\n    mkdirp(directory)\n  File \"/vagrant/inbox/util/file.py\", line 43, in mkdirp\n    os.makedirs(path)\n  File \"/usr/lib/python2.7/os.py\", line 150, in makedirs\n    makedirs(head, mode)\n  File \"/usr/lib/python2.7/os.py\", line 150, in makedirs\n    makedirs(head, mode)\n  File \"/usr/lib/python2.7/os.py\", line 150, in makedirs\n    makedirs(head, mode)\n  File \"/usr/lib/python2.7/os.py\", line 150, in makedirs\n    makedirs(head, mode)\n  File \"/usr/lib/python2.7/os.py\", line 150, in makedirs\n    makedirs(head, mode)\n  File \"/usr/lib/python2.7/os.py\", line 150, in makedirs\n    makedirs(head, mode)\n  File \"/usr/lib/python2.7/os.py\", line 150, in makedirs\n    makedirs(head, mode)\n  File \"/usr/lib/python2.7/os.py\", line 157, in makedirs\n    mkdir(name, mode)\nOSError: [Errno 13] Permission denied: '/var/lib/inboxapp'\n", "exception": "OSError: [Errno 13] Permission denied: '/var/lib/inboxapp'\n"}}
```




