### PR TITLE
Let's scale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 dist: trusty
+services:
+  - mysql
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required
+dist: trusty
+
 cache:
   directories:
     - /home/travis/virtualenv

--- a/inbox/api/jsc_api.py
+++ b/inbox/api/jsc_api.py
@@ -129,9 +129,9 @@ def auth_callback():
     g.parser.add_argument('target', type=int, location='args')
     args = strict_parse_args(g.parser, request.args)
 
-    shard = args.get('target', 0) >> 48
+    target = args.get('target') or 0
 
-    with session_scope(shard) as db_session:
+    with session_scope(target) as db_session:
         account = db_session.query(Account).filter_by(email_address=args['email']).first()
 
         updating_account = False
@@ -194,7 +194,7 @@ def auth_callback():
 
 @app.route('/create_account', methods=['POST'])
 def create_account():
-    g.parser.add_argument('target', type=int, location='args')
+    g.parser.add_argument('target', type=int, location='form')
     g.parser.add_argument('email', required=True, type=bounded_str, location='form')
     g.parser.add_argument('smtp_host', required=True, type=bounded_str, location='form')
     g.parser.add_argument('smtp_port', type=int, location='form')
@@ -207,9 +207,9 @@ def create_account():
     g.parser.add_argument('ssl_required', required=True, type=bool, location='form')
 
     args = strict_parse_args(g.parser, request.args)
-    shard = (args.get('target') or 0) >> 48
+    target = args.get('target') or 0
 
-    with session_scope(shard) as db_session:
+    with session_scope(target) as db_session:
         account = db_session.query(Account).filter_by(email_address=args['email']).first()
 
         provider_auth_info = dict(provider='custom',

--- a/migrations/versions/38a96fe9323e_adds_index_to_message_reply_to_message_.py
+++ b/migrations/versions/38a96fe9323e_adds_index_to_message_reply_to_message_.py
@@ -1,0 +1,23 @@
+"""adds index to message.reply_to_message_id
+
+Revision ID: 38a96fe9323e
+Revises: 531779ade3d2
+Create Date: 2018-02-06 15:52:34.142593
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '38a96fe9323e'
+down_revision = '531779ade3d2'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(text("CREATE INDEX `ix_message_reply_to_message_id` ON `message` (`reply_to_message_id`)"))
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute(text("ALTER TABLE message DROP INDEX `ix_message_reply_to_message_id`"))

--- a/migrations/versions/531779ade3d2_adds_index_to_message_thread_id.py
+++ b/migrations/versions/531779ade3d2_adds_index_to_message_thread_id.py
@@ -1,0 +1,23 @@
+"""adds index to message.thread_id
+
+Revision ID: 531779ade3d2
+Revises: 780b1dabd51
+Create Date: 2018-02-06 15:45:59.965603
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '531779ade3d2'
+down_revision = '780b1dabd51'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(text("CREATE INDEX `ix_message_thread_id` ON `message` (`thread_id`)"))
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute(text("ALTER TABLE message DROP INDEX `ix_message_thread_id`"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,3 +68,5 @@ tox==2.3.1
 nylas==1.2.3
 cffi>=1.6
 pyasn1==0.2.3
+six==1.11.0
+colorama==0.3.9

--- a/setup.sh
+++ b/setup.sh
@@ -76,8 +76,6 @@ apt-get -y install git \
                    mercurial \
                    wget \
                    supervisor \
-                   mysql-server \
-                   mysql-client \
                    python \
                    python-dev \
                    python-pip \

--- a/setup.sh
+++ b/setup.sh
@@ -98,6 +98,12 @@ apt-get -y install git \
                    lua5.2 \
                    liblua5.2-dev \
 
+if [ "$CI" != "true" ];
+then
+    color '35;1' 'Not on CI. Installing mysql packages...'
+    apt-get -y install mysql-server mysql-client
+fi
+
 # Switch to a temporary directory to install dependencies, since the source
 # directory might be mounted from a VM host with weird permissions.
 src_dir=$(pwd)


### PR DESCRIPTION
Main changes:

- Start using S3 for file storage instead of disk
- Fix the "target" parameters for the account creation methods
- enable_sync and suspend_sync endpoints do not need the target anymore (they can be extracted from the account id)
- Make the `six` and `colorama` packages' versions explicit

Story #154051765