### PR TITLE
Changing IMAP connection timeout

### DIFF
--- a/inbox/auth/generic.py
+++ b/inbox/auth/generic.py
@@ -365,7 +365,7 @@ def create_imap_connection(host, port, ssl_required, use_timeout=True):
 
     """
     use_ssl = port == 993
-    timeout = 120 if use_timeout else None
+    timeout = 10 if use_timeout else None
 
     # TODO: certificate pinning for well known sites
     context = create_default_context()


### PR DESCRIPTION
From 2 minutes to 10 seconds - waiting 2 minutes is just too much and causes a long wait when setting up an account
