### PR TITLE
Use a lock for message category changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pip>=19.0.3
 certifi==2018.10.15
 nylas-production-python>=0.4.3
 coverage==4.2
@@ -63,7 +64,7 @@ psutil==3.3.0
 pyopenssl>=0.15.1
 gevent_openssl==1.2
 backports.ssl==0.0.9
-git+https://github.com/closeio/imapclient.git@cfd0f6c83b38b6fb8d38487f8ae5d1adf4ba2c58#egg=imapclient
+git+https://github.com/closeio/imapclient.git@b9c12026fc61da29b5ddf9122faf6c6c5b09667d#egg=imapclient
 tldextract==1.7.5
 tox==2.3.1
 nylas==1.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ psutil==3.3.0
 pyopenssl>=0.15.1
 gevent_openssl==1.2
 backports.ssl==0.0.9
-git+https://github.com/closeio/imapclient.git@b9c12026fc61da29b5ddf9122faf6c6c5b09667d#egg=imapclient
+git+https://github.com/GlauberrBatista/imapclient.git@eefa5348e7d9f114e5f01721cc10e0e57abec5d7#egg=imapclient
 tldextract==1.7.5
 tox==2.3.1
 nylas==1.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ psutil==3.3.0
 pyopenssl>=0.15.1
 gevent_openssl==1.2
 backports.ssl==0.0.9
-git+https://github.com/mjs/imapclient.git@77047bafd9a82f3bb1faa5e909d776b7a2e1b432#egg=imapclient
+git+https://github.com/closeio/imapclient.git@cfd0f6c83b38b6fb8d38487f8ae5d1adf4ba2c58#egg=imapclient
 tldextract==1.7.5
 tox==2.3.1
 nylas==1.2.3


### PR DESCRIPTION
This fixes race conditions on IMAP accounts when moving messages
